### PR TITLE
Unconfig script, and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,10 @@ We have created integration tests to cover the most important scenarios connecte
     - updating commercetools API Extension to point to our development server
 - `npm run config` - set up the required basic configuration in commercetools:
     1. custom coupon type - needed to store coupons codes inside the [Cart](https://docs.commercetools.com/api/projects/carts) object
-    2. coupon tax category - needed for any coupon or gift card with a fixed amount discount
+    2. (optionally based on `APPLY_CART_DISCOUNT_AS_CT_DIRECT_DISCOUNT` as this is not required for direct discounts) coupon tax category - needed for any coupon or gift card with a fixed amount discount
+- `npm run unconfig` - unconfiguration required for these connector definitions in commercetools:
+    1. custom coupon type - needed to store coupons codes inside the [Cart](https://docs.commercetools.com/api/projects/carts) object
+    2. (will be skipped for `APPLY_CART_DISCOUNT_AS_CT_DIRECT_DISCOUNT=true`, as this should not be configured) coupon tax category - needed for any coupon or gift card with a fixed amount discount
 - `npm run test` - run Jest tests
 - `npm run migrate` - migrate data from commercetools to Voucherify. Arguments:
     - `type` - required - type of data which you want to migrate. Values: `products`, `orders`, `customers`
@@ -474,6 +477,8 @@ If you found a bug or want to suggest a new feature, please file a GitHub issue.
   - code refactoring (lowering cognitive complexity)
   - fixed package vulnerabilities
   - coupon tax category is not being configured in Direct Discount mode. `[APPLY_CART_DISCOUNT_AS_CT_DIRECT_DISCOUNT=true]`
+  - script that undoes `npm run config` - `npm run unconfig`
+  - added `npm run unconfig` to `npm run ct-connect-post-undeploy` command
 - 2024-01-31 `v6.0.6`
   - remove fallback to `coupon.order?.total_discount_amount` that caused too great promotions in some cases
   - added test to test this case ^

--- a/voucherify-service/package.json
+++ b/voucherify-service/package.json
@@ -22,13 +22,14 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "config": "nest start --config nest-commander.json -- config",
+    "unconfig": "nest start --config nest-commander.json -- unconfig",
     "api-extension-list": "nest start --config nest-commander.json -- integration-list",
     "api-extension-add": "nest start --config nest-commander.json -- integration-add",
     "api-extension-update": "nest start --config nest-commander.json -- integration-update",
     "api-extension-delete": "nest start --config nest-commander.json -- integration-delete",
     "migrate": "nest start --config nest-commander.json -- migrate",
     "ct-connect-post-deploy": "npm run build && npm run config && npm run api-extension-add",
-    "ct-connect-pre-undeploy": "npm run api-extension-delete"
+    "ct-connect-pre-undeploy": "npm run unconfig && npm run api-extension-delete"
   },
   "dependencies": {
     "@commercetools/platform-sdk": "2.7.0",

--- a/voucherify-service/src/app.module.ts
+++ b/voucherify-service/src/app.module.ts
@@ -18,6 +18,7 @@ import { ApiExtensionDeleteCommand } from './cli/api-extension-delete.command';
 import { ApiExtensionUpdateCommand } from './cli/api-extension-update.command';
 import { ApiExtensionListCommand } from './cli/api-extension-list.command';
 import { ConfigCommand } from './cli/config.command';
+import { UnconfigCommand } from './cli/unconfig.command';
 import { MigrateCommand } from './cli/migrate.command';
 import { OrderMapper } from './integration/utils/mappers/order';
 import { ValidationSchema } from './configs/validationSchema';
@@ -49,6 +50,7 @@ import { VoucherifyService } from './voucherify/voucherify.service';
     ApiExtensionDeleteCommand,
     MigrateCommand,
     ConfigCommand,
+    UnconfigCommand,
     ApiExtensionListCommand,
     ApiExtensionUpdateCommand,
     OrderMapper,

--- a/voucherify-service/src/cli/unconfig.command.ts
+++ b/voucherify-service/src/cli/unconfig.command.ts
@@ -5,13 +5,13 @@ import { CustomTypesService } from '../commercetools/custom-types/custom-types.s
 import { ConfigService } from '@nestjs/config';
 
 @Command({
-  name: 'config',
-  description: `Set up the required basic configuration in commercetools:
+  name: 'unconfig',
+  description: `Unset up the required basic configuration in commercetools:
   1. custom coupon type - needed to store coupons codes inside the [Cart](https://docs.commercetools.com/api/projects/carts) object
   (optionally based on "APPLY_CART_DISCOUNT_AS_CT_DIRECT_DISCOUNT") 2. coupon tax category - needed for any coupon or gift card with a fixed amount discount
   `,
 })
-export class ConfigCommand extends CommandRunner {
+export class UnconfigCommand extends CommandRunner {
   constructor(
     private readonly typesService: CustomTypesService,
     private readonly taxCategoriesService: TaxCategoriesService,
@@ -27,18 +27,18 @@ export class ConfigCommand extends CommandRunner {
     const totalSteps: number = applyCartDiscountAsCtDirectDiscount ? 1 : 2;
     let currentStep = 1;
     const spinnerCouponsTypes = loadingCli(
-      `[${currentStep}/${totalSteps}] Attempt to configure required coupon types in Commercetools`,
+      `[${currentStep}/${totalSteps}] Attempt to unconfigure required coupon types in Commercetools`,
     ).start();
 
     const { success: couponTypesCreated } =
-      await this.typesService.configureCouponTypes();
+      await this.typesService.unconfigureCouponTypes();
     if (couponTypesCreated) {
       spinnerCouponsTypes.succeed(
-        `[${currentStep}/${totalSteps}] Coupon custom-types configured`,
+        `[${currentStep}/${totalSteps}] Coupon custom-types unconfigured`,
       );
     } else {
       spinnerCouponsTypes.fail(
-        `[${currentStep}/${totalSteps}] Could not configure coupon codes`,
+        `[${currentStep}/${totalSteps}] Could not unconfigure coupon codes`,
       );
     }
 
@@ -47,18 +47,18 @@ export class ConfigCommand extends CommandRunner {
     }
     currentStep++;
     const spinnerTaxCategories = loadingCli(
-      `[${currentStep}/${totalSteps}] Attempt to configure coupon tax categories in Commercetools`,
+      `[${currentStep}/${totalSteps}] Attempt to unconfigure coupon tax categories in Commercetools`,
     ).start();
 
-    const couponTaxCategoriesCreated =
-      await this.taxCategoriesService.configureCouponTaxCategory();
+    const { success: couponTaxCategoriesCreated } =
+      await this.taxCategoriesService.unconfigureCouponTaxCategory();
     if (couponTaxCategoriesCreated) {
       spinnerTaxCategories.succeed(
-        `[${currentStep}/${totalSteps}] Coupon tax categories configured`,
+        `[${currentStep}/${totalSteps}] Coupon tax categories unconfigured`,
       );
     } else {
       spinnerTaxCategories.fail(
-        `[${currentStep}/${totalSteps}] Could not configure coupon tax categories`,
+        `[${currentStep}/${totalSteps}] Could not unconfigure coupon tax categories`,
       );
     }
   }

--- a/voucherify-service/src/commercetools/store-actions/order-paid-actions.ts
+++ b/voucherify-service/src/commercetools/store-actions/order-paid-actions.ts
@@ -72,8 +72,14 @@ export class OrderPaidActions implements OrderPaidActions {
   }
 
   public async findPayment(id: string): Promise<Payment> {
-    return (await this.ctClient.payments().withId({ ID: id }).get().execute())
-      ?.body;
+    return (
+      await this.ctClient
+        .payments()
+        .withId({ ID: id })
+        .get()
+        .execute()
+        .catch((e) => e)
+    )?.body;
   }
 
   public async getCustomMetadataForOrder(

--- a/voucherify-service/src/commercetools/tax-categories/tax-categories.service.ts
+++ b/voucherify-service/src/commercetools/tax-categories/tax-categories.service.ts
@@ -47,7 +47,8 @@ export class TaxCategoriesService {
     const { statusCode, body } = await ctClient
       .taxCategories()
       .get({ queryArgs: { where: 'name="coupon"' } })
-      .execute();
+      .execute()
+      .catch((e) => e);
 
     if ([200, 201].includes(statusCode) && body.count === 1) {
       this.logger.debug({
@@ -65,7 +66,8 @@ export class TaxCategoriesService {
           rates: [],
         },
       })
-      .execute();
+      .execute()
+      .catch((e) => e);
 
     if (![200, 201].includes(response.statusCode)) {
       return null;
@@ -153,7 +155,8 @@ export class TaxCategoriesService {
           actions,
         },
       })
-      .execute();
+      .execute()
+      .catch((e) => e);
 
     const success = [200, 201].includes(response.statusCode);
     if (success) {
@@ -166,6 +169,34 @@ export class TaxCategoriesService {
     }
 
     return this.getCashedCouponTaxCategoryOrFromNewRequest();
+  }
+
+  public async unconfigureCouponTaxCategory(): Promise<{ success: boolean }> {
+    const ctClient = this.commerceToolsConnectorService.getClient();
+    const couponTaxCategory =
+      await this.getCashedCouponTaxCategoryOrFromNewRequest();
+
+    const response = await ctClient
+      .taxCategories()
+      .withId({ ID: couponTaxCategory.id })
+      .delete({
+        queryArgs: {
+          version: couponTaxCategory.version,
+        },
+      })
+      .execute()
+      .catch((e) => e);
+
+    const success = [200, 201].includes(response.statusCode);
+    if (success) {
+      this.logger.debug({ msg: 'Deleted coupon tax category' });
+      return { success: true };
+    }
+    const msg = 'Could not delete coupon tax category';
+    this.logger.error({
+      msg,
+    });
+    return { success: false };
   }
 
   private calcOperationsToGetDesiredRates(
@@ -219,7 +250,8 @@ export class TaxCategoriesService {
           ],
         },
       })
-      .execute();
+      .execute()
+      .catch((e) => e);
     const success = [200, 201].includes(response.statusCode);
     if (success) {
       this.couponTaxCategory = null;


### PR DESCRIPTION
Why?
- Poproszono nas o dodanie skyptu `unconfig` który defakto cofa `npm run config`.


What?
- Dodałem skrypt `unconfig`
- Okazało się, że `ctClient` przy response 400+ wyrzuca błąd przy czym do tej pory w wielu miejscach wygląda jakbyśmy o tym nie wiedzieli. Bo w kolejnych liniach sprawdzamy czy jest response status 200/201, ale to w przypadku response.status 400 się to sprawdzenie nigdy nie wykona... a co za tym idzie wywali się `loadingCli` bo tam nie było obsługi tego błedu - w przypadku `npm run config/unconfig`
tak więc np:
```
private async createCouponType(
    typeDefinition: TypeDraft,
  ): Promise<{ success: boolean }> {
    const ctClient = this.commerceToolsConnectorService.getClient();

    const response = await ctClient
      .types()
      .post({ body: typeDefinition })
      .execute()
      .catch((e) => e);  //<-- to zostało dodane!!!!!!!!!!!!!!!!!!!
    if (![200, 201].includes(response.statusCode)) {
      const errorMsg = `Type: "${typeDefinition.key}" could not be created`;
      this.logger.error({
        msg: errorMsg,
        statusCode: response.statusCode,
        body: response.body,
      });
      return { success: false };
    }

    this.logger.debug({
      msg: `Type: "${typeDefinition.key}" created`,
      type: response.body,
    });

    return { success: true };
  }
  ```